### PR TITLE
Update Dockerfile: infinity

### DIFF
--- a/langchain/templates/2-llm-rag/app_infinity/Dockerfile
+++ b/langchain/templates/2-llm-rag/app_infinity/Dockerfile
@@ -1,6 +1,8 @@
 ARG MODEL
 ARG PORT
 
-FROM michaelf34/infinity:0.0.40
-
-ENTRYPOINT /bin/sh -c infinity_emb --port $PORT --model-name-or-path $MODEL
+FROM michaelf34/infinity:0.0.63
+# cache the model into the dockerfile
+RUN /bin/sh -c infinity_emb v2 --port $PORT --model-id $MODEL --preload-only
+# execute the model. Check all CLI arguments here: https://michaelfeil.eu/infinity/0.0.63/cli_v2/
+ENTRYPOINT /bin/sh -c infinity_emb v2 --port $PORT --model-id $MODEL


### PR DESCRIPTION
This pull request updates the `Dockerfile` for the `2-llm-rag` application to use a newer version of the `infinity` image and modifies the entrypoint to include a preloading step for the model.

Dockerfile updates:

* [`langchain/templates/2-llm-rag/app_infinity/Dockerfile`](diffhunk://#diff-46d89b97fe94bac714a2c2cdbdcd12834aedbd677bc0018340351a41a2b0f739L4-R8): Updated the `infinity` image from version `0.0.40` to `0.0.63`.
* [`langchain/templates/2-llm-rag/app_infinity/Dockerfile`](diffhunk://#diff-46d89b97fe94bac714a2c2cdbdcd12834aedbd677bc0018340351a41a2b0f739L4-R8): Added a command to preload the model using the `--preload-only` flag before executing it.
* [`langchain/templates/2-llm-rag/app_infinity/Dockerfile`](diffhunk://#diff-46d89b97fe94bac714a2c2cdbdcd12834aedbd677bc0018340351a41a2b0f739L4-R8): Updated the entrypoint to use the `v2` CLI of the `infinity_emb` command and provided a link to the CLI arguments documentation.