### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/Autogen/Autogen.ipynb
+++ b/Autogen/Autogen.ipynb
@@ -22,7 +22,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -qqq pyautogen[retrievechat] flaml[automl] openai langchain chromadb sentence-transformers"
+        "!pip install -qqq ag2[retrievechat] flaml[automl] openai langchain chromadb sentence-transformers"
       ]
     },
     {

--- a/Autogen/Autogen_groupchat_RAG.ipynb
+++ b/Autogen/Autogen_groupchat_RAG.ipynb
@@ -15,7 +15,7 @@
     "Some extra dependencies are needed for this notebook, which can be installed via pip:\n",
     "\n",
     "```bash\n",
-    "pip install pyautogen[retrievechat]\n",
+    "pip install ag2[retrievechat]\n",
     "```\n",
     "\n",
     "For more information, please refer to the [installation guide](/docs/installation/).\n",

--- a/Autogen/autogen-ollama-gemma.ipynb
+++ b/Autogen/autogen-ollama-gemma.ipynb
@@ -1930,8 +1930,8 @@
      "text": [
       "Collecting openai\r\n",
       "  Downloading openai-1.13.3-py3-none-any.whl.metadata (18 kB)\r\n",
-      "Collecting pyautogen\r\n",
-      "  Downloading pyautogen-0.2.16-py3-none-any.whl.metadata (18 kB)\r\n",
+      "Collecting ag2\r\n",
+      "  Downloading ag2-0.2.16-py3-none-any.whl.metadata (18 kB)\r\n",
       "Requirement already satisfied: anyio<5,>=3.5.0 in /opt/conda/lib/python3.10/site-packages (from openai) (4.2.0)\r\n",
       "Requirement already satisfied: distro<2,>=1.7.0 in /opt/conda/lib/python3.10/site-packages (from openai) (1.9.0)\r\n",
       "Requirement already satisfied: httpx<1,>=0.23.0 in /opt/conda/lib/python3.10/site-packages (from openai) (0.27.0)\r\n",
@@ -1939,14 +1939,14 @@
       "Requirement already satisfied: sniffio in /opt/conda/lib/python3.10/site-packages (from openai) (1.3.0)\r\n",
       "Requirement already satisfied: tqdm>4 in /opt/conda/lib/python3.10/site-packages (from openai) (4.66.1)\r\n",
       "Requirement already satisfied: typing-extensions<5,>=4.7 in /opt/conda/lib/python3.10/site-packages (from openai) (4.9.0)\r\n",
-      "Collecting diskcache (from pyautogen)\r\n",
+      "Collecting diskcache (from ag2)\r\n",
       "  Downloading diskcache-5.6.3-py3-none-any.whl.metadata (20 kB)\r\n",
-      "Requirement already satisfied: docker in /opt/conda/lib/python3.10/site-packages (from pyautogen) (7.0.0)\r\n",
-      "Collecting flaml (from pyautogen)\r\n",
+      "Requirement already satisfied: docker in /opt/conda/lib/python3.10/site-packages (from ag2) (7.0.0)\r\n",
+      "Collecting flaml (from ag2)\r\n",
       "  Downloading FLAML-2.1.1-py3-none-any.whl.metadata (15 kB)\r\n",
-      "Requirement already satisfied: python-dotenv in /opt/conda/lib/python3.10/site-packages (from pyautogen) (1.0.0)\r\n",
-      "Requirement already satisfied: termcolor in /opt/conda/lib/python3.10/site-packages (from pyautogen) (2.4.0)\r\n",
-      "Collecting tiktoken (from pyautogen)\r\n",
+      "Requirement already satisfied: python-dotenv in /opt/conda/lib/python3.10/site-packages (from ag2) (1.0.0)\r\n",
+      "Requirement already satisfied: termcolor in /opt/conda/lib/python3.10/site-packages (from ag2) (2.4.0)\r\n",
+      "Collecting tiktoken (from ag2)\r\n",
       "  Downloading tiktoken-0.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.6 kB)\r\n",
       "Requirement already satisfied: idna>=2.8 in /opt/conda/lib/python3.10/site-packages (from anyio<5,>=3.5.0->openai) (3.6)\r\n",
       "Requirement already satisfied: exceptiongroup>=1.0.2 in /opt/conda/lib/python3.10/site-packages (from anyio<5,>=3.5.0->openai) (1.2.0)\r\n",
@@ -1955,16 +1955,16 @@
       "Requirement already satisfied: h11<0.15,>=0.13 in /opt/conda/lib/python3.10/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.14.0)\r\n",
       "Requirement already satisfied: annotated-types>=0.4.0 in /opt/conda/lib/python3.10/site-packages (from pydantic<3,>=1.9.0->openai) (0.6.0)\r\n",
       "Requirement already satisfied: pydantic-core==2.14.6 in /opt/conda/lib/python3.10/site-packages (from pydantic<3,>=1.9.0->openai) (2.14.6)\r\n",
-      "Requirement already satisfied: packaging>=14.0 in /opt/conda/lib/python3.10/site-packages (from docker->pyautogen) (21.3)\r\n",
-      "Requirement already satisfied: requests>=2.26.0 in /opt/conda/lib/python3.10/site-packages (from docker->pyautogen) (2.31.0)\r\n",
-      "Requirement already satisfied: urllib3>=1.26.0 in /opt/conda/lib/python3.10/site-packages (from docker->pyautogen) (1.26.18)\r\n",
-      "Requirement already satisfied: NumPy>=1.17.0rc1 in /opt/conda/lib/python3.10/site-packages (from flaml->pyautogen) (1.26.4)\r\n",
-      "Requirement already satisfied: regex>=2022.1.18 in /opt/conda/lib/python3.10/site-packages (from tiktoken->pyautogen) (2023.12.25)\r\n",
-      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /opt/conda/lib/python3.10/site-packages (from packaging>=14.0->docker->pyautogen) (3.1.1)\r\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /opt/conda/lib/python3.10/site-packages (from requests>=2.26.0->docker->pyautogen) (3.3.2)\r\n",
+      "Requirement already satisfied: packaging>=14.0 in /opt/conda/lib/python3.10/site-packages (from docker->ag2) (21.3)\r\n",
+      "Requirement already satisfied: requests>=2.26.0 in /opt/conda/lib/python3.10/site-packages (from docker->ag2) (2.31.0)\r\n",
+      "Requirement already satisfied: urllib3>=1.26.0 in /opt/conda/lib/python3.10/site-packages (from docker->ag2) (1.26.18)\r\n",
+      "Requirement already satisfied: NumPy>=1.17.0rc1 in /opt/conda/lib/python3.10/site-packages (from flaml->ag2) (1.26.4)\r\n",
+      "Requirement already satisfied: regex>=2022.1.18 in /opt/conda/lib/python3.10/site-packages (from tiktoken->ag2) (2023.12.25)\r\n",
+      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /opt/conda/lib/python3.10/site-packages (from packaging>=14.0->docker->ag2) (3.1.1)\r\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /opt/conda/lib/python3.10/site-packages (from requests>=2.26.0->docker->ag2) (3.3.2)\r\n",
       "Downloading openai-1.13.3-py3-none-any.whl (227 kB)\r\n",
       "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m227.4/227.4 kB\u001b[0m \u001b[31m2.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
-      "\u001b[?25hDownloading pyautogen-0.2.16-py3-none-any.whl (207 kB)\r\n",
+      "\u001b[?25hDownloading ag2-0.2.16-py3-none-any.whl (207 kB)\r\n",
       "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m208.0/208.0 kB\u001b[0m \u001b[31m6.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
       "\u001b[?25hDownloading diskcache-5.6.3-py3-none-any.whl (45 kB)\r\n",
       "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m45.5/45.5 kB\u001b[0m \u001b[31m2.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
@@ -1972,13 +1972,13 @@
       "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m295.2/295.2 kB\u001b[0m \u001b[31m10.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
       "\u001b[?25hDownloading tiktoken-0.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.8 MB)\r\n",
       "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.8/1.8 MB\u001b[0m \u001b[31m19.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
-      "\u001b[?25hInstalling collected packages: flaml, diskcache, tiktoken, openai, pyautogen\r\n",
-      "Successfully installed diskcache-5.6.3 flaml-2.1.1 openai-1.13.3 pyautogen-0.2.16 tiktoken-0.6.0\r\n"
+      "\u001b[?25hInstalling collected packages: flaml, diskcache, tiktoken, openai, ag2\r\n",
+      "Successfully installed diskcache-5.6.3 flaml-2.1.1 openai-1.13.3 ag2-0.2.16 tiktoken-0.6.0\r\n"
      ]
     }
    ],
    "source": [
-    "!pip install --upgrade openai pyautogen"
+    "!pip install --upgrade openai ag2"
    ]
   },
   {

--- a/Autogen/autogen_groupchat.ipynb
+++ b/Autogen/autogen_groupchat.ipynb
@@ -70,7 +70,7 @@
         }
       ],
       "source": [
-        "!pip install -qqq pyautogen~=0.1.0 flaml[automl] openai langchain chromadb sentence-transformers"
+        "!pip install -qqq ag2~=0.1.0 flaml[automl] openai langchain chromadb sentence-transformers"
       ]
     },
     {

--- a/Autogen/autogen_webscarp.ipynb
+++ b/Autogen/autogen_webscarp.ipynb
@@ -71,7 +71,7 @@
         }
       ],
       "source": [
-        "!pip install -qqq pyautogen~=0.1.0 flaml[automl] openai langchain chromadb sentence-transformers requests bs4"
+        "!pip install -qqq ag2~=0.1.0 flaml[automl] openai langchain chromadb sentence-transformers requests bs4"
       ]
     },
     {

--- a/crew-ai-examples/notebooks/GenAI_CrashCourse_Module_4_CrewAI.ipynb
+++ b/crew-ai-examples/notebooks/GenAI_CrashCourse_Module_4_CrewAI.ipynb
@@ -1350,7 +1350,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install pyautogen"
+        "!pip install ag2"
       ]
     },
     {


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
